### PR TITLE
Use github access token for the api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./
         with:
           compiler: ${{ matrix.dc }}
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify D compiler ($DC)
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: ./
         with:
           compiler: ${{ matrix.dc }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify D compiler ($DC)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -58,3 +58,33 @@ Valid version examples are:
 - `ldc-1.18.0-beta1`
 - `dmd-master`
 - `ldc-master`
+
+## ldc-master
+
+To avoid Github API request throttling, an extra parameter must be supplied to
+use ldc-master toolchain reliably:
+
+```yml
+name: Run all D Tests
+on: [push, pull_request]
+
+jobs:
+    test:
+        name: Dub Tests
+        strategy:
+            matrix:
+                os: [ubuntu-latest, osx-lastest, windows-latest]
+                dc: [ldc-master]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v1
+
+            - name: Install D compiler
+              uses: mihails-strasuns/setup-dlang@v0.3.0
+              with:
+                  compiler: ${{ matrix.dc }}
+                  gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Run tests
+              run: dub -q test
+```

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -109,9 +109,67 @@ function dmd(version) {
         }
     });
 }
+function ldc_resolve_master(gh_token) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let suffix, ext;
+        switch (process.platform) {
+            case "win32":
+                suffix = 'windows-multilib';
+                ext = '7z';
+                break;
+            case "linux":
+                suffix = 'linux-x86_64';
+                ext = 'tar.xz';
+                break;
+            case "darwin":
+                suffix = 'osx-x86_64';
+                ext = 'tar.xz';
+                break;
+            default:
+                throw new Error("unsupported platform: " + process.platform);
+        }
+        if (!gh_token)
+            throw new Error("'gh_token' parameter must be set to use ldc-master");
+        let json = yield utils_1.body_as_text(`https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI`, gh_token);
+        let assets = JSON.parse(json)["assets"];
+        if (assets == undefined) {
+            console.log(json);
+            throw new Error("Couldn't load assets json");
+        }
+        if (assets.length == 0)
+            throw new Error("No assets found for LDC CI release");
+        assets.sort(function (a, b) {
+            const date_a = Date.parse(a["updated_at"]);
+            const date_b = Date.parse(b["updated_at"]);
+            return date_a > date_b ? -1 : 1;
+        });
+        assets = assets
+            .map(function (asset) {
+            let matches = asset["name"].match(/^ldc2?-([0-9a-fA-F]{5,12})-(.+)/);
+            if (!matches)
+                throw new Error(`Unexpected naming format for the latest LDC asset: ${latest}`);
+            return {
+                name: matches[0],
+                version: matches[1],
+                suffix: matches[2]
+            };
+        })
+            .filter(function (asset) {
+            return asset.suffix == `${suffix}.${ext}`;
+        });
+        const latest = assets[0];
+        return {
+            name: "ldc2",
+            version: latest.version,
+            url: "https://github.com/ldc-developers/ldc/releases/download/CI/" + latest.name,
+            binpath: (process.platform == "win32") ?
+                `\\ldc2-${latest.version}-${suffix}\\bin` :
+                `/ldc2-${latest.version}-${suffix}/bin`
+        };
+    });
+}
 function ldc(version, gh_token) {
     return __awaiter(this, void 0, void 0, function* () {
-        let ci = false;
         switch (version) {
             case "latest":
                 version = yield utils_1.body_as_text("https://ldc-developers.github.io/LATEST");
@@ -120,32 +178,11 @@ function ldc(version, gh_token) {
                 version = yield utils_1.body_as_text("https://ldc-developers.github.io/LATEST_BETA");
                 break;
             case "master":
-                let json = yield utils_1.body_as_text(`https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI`, gh_token);
-                let assets = JSON.parse(json)["assets"];
-                if (assets == undefined) {
-                    console.error("Couldn't load assets json");
-                    console.log(json);
-                }
-                if (assets.length == 0)
-                    throw new Error("No assets found for LDC CI release");
-                assets.sort(function (a, b) {
-                    const date_a = Date.parse(a["updated_at"]);
-                    const date_b = Date.parse(b["updated_at"]);
-                    return date_a > date_b ? -1 : 1;
-                });
-                const latest = assets[0]["name"];
-                const matches = latest.match(/^ldc2?-([0-9a-fA-F]{5,12})-.+/);
-                if (!matches)
-                    throw new Error(`Unexpected naming format for the latest LDC asset: ${latest}`);
-                version = matches[1];
-                ci = true;
-                break;
+                return yield ldc_resolve_master(gh_token);
         }
-        if (!ci && !version.match(/^(\d+)\.(\d+)\.(\d+)/))
+        if (!version.match(/^(\d+)\.(\d+)\.(\d+)/))
             throw new Error("unrecognized LDC version: " + version);
-        const base_url = ci ?
-            `https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-${version}`
-            : `https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc2-${version}`;
+        const base_url = `https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc2-${version}`;
         switch (process.platform) {
             case "win32": return {
                 name: "ldc2",

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -10,14 +10,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("./utils");
-function compiler(description) {
+function compiler(description, gh_token) {
     return __awaiter(this, void 0, void 0, function* () {
         const matches = description.match(/^(\w+)-(.+)$/);
         if (!matches)
             throw new Error("invalid compiler string: " + description);
         switch (matches[1]) {
             case "dmd": return yield dmd(matches[2]);
-            case "ldc": return yield ldc(matches[2]);
+            case "ldc": return yield ldc(matches[2], gh_token);
             default: throw new Error("unrecognized compiler: " + matches[1]);
         }
     });
@@ -109,7 +109,7 @@ function dmd(version) {
         }
     });
 }
-function ldc(version) {
+function ldc(version, gh_token) {
     return __awaiter(this, void 0, void 0, function* () {
         let ci = false;
         switch (version) {
@@ -120,7 +120,12 @@ function ldc(version) {
                 version = yield utils_1.body_as_text("https://ldc-developers.github.io/LATEST_BETA");
                 break;
             case "master":
-                let assets = JSON.parse(yield utils_1.body_as_text("https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI"))["assets"];
+                let json = yield utils_1.body_as_text(`https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI`, gh_token);
+                let assets = JSON.parse(json)["assets"];
+                if (assets == undefined) {
+                    console.error("Couldn't load assets json");
+                    console.log(json);
+                }
                 if (assets.length == 0)
                     throw new Error("No assets found for LDC CI release");
                 assets.sort(function (a, b) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,7 +26,8 @@ function run() {
             if (process.arch != "x64")
                 throw new Error("Only x64 arch is supported by all platforms");
             const input = core.getInput('compiler') || "dmd-latest";
-            const descr = yield compiler_1.compiler(input);
+            const gh_token = core.getInput('gh_token') || "";
+            const descr = yield compiler_1.compiler(input, gh_token);
             console.log(`Enabling ${input}`);
             const cache_tag = descr.name + "-" + descr.version + (descr.download_dub ? "+dub" : "");
             let cached = tc.find('dc', cache_tag);

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,9 @@ function run() {
                 }
                 cached = yield tc.cacheDir(dc_path, 'dc', cache_tag);
             }
-            core.addPath(cached + descr.binpath);
+            const binpath = cached + descr.binpath;
+            console.log("Adding '" + binpath + "' to path");
+            core.addPath(binpath);
             core.exportVariable("DC", descr.name);
             console.log("Done");
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,9 +17,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const httpm = __importStar(require("typed-rest-client/HttpClient"));
-function body_as_text(url) {
+const Handlers_1 = require("typed-rest-client/Handlers");
+function body_as_text(url, token = '') {
     return __awaiter(this, void 0, void 0, function* () {
-        let client = new httpm.HttpClient("mihails-strasuns/setup-dlang");
+        const bearer = token ? [new Handlers_1.BearerCredentialHandler(token)] : undefined;
+        let client = new httpm.HttpClient("mihails-strasuns/setup-dlang", bearer);
         return (yield (yield client.get(url)).readBody()).trim();
     });
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -115,9 +115,65 @@ async function dmd(version: string): Promise<CompilerDescription> {
     }
 }
 
-async function ldc(version: string, gh_token: string): Promise<CompilerDescription> {
-    let ci = false;
+async function ldc_resolve_master(gh_token: string): Promise<CompilerDescription> {
+    let suffix, ext;
 
+    switch (process.platform) {
+        case "win32": suffix = 'windows-multilib'; ext = '7z'; break;
+        case "linux": suffix = 'linux-x86_64'; ext = 'tar.xz'; break;
+        case "darwin": suffix = 'osx-x86_64'; ext = 'tar.xz'; break;
+        default:
+            throw new Error("unsupported platform: " + process.platform);
+    }
+
+    if (!gh_token)
+        throw new Error("'gh_token' parameter must be set to use ldc-master");
+
+    let json = await body_as_text(
+        `https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI`,
+        gh_token
+    );
+    let assets = JSON.parse(json)["assets"];
+    if (assets == undefined) {
+        console.log(json)
+        throw new Error("Couldn't load assets json");
+    }
+    if (assets.length == 0)
+        throw new Error("No assets found for LDC CI release");
+
+    assets.sort(function (a, b) {
+        const date_a = Date.parse(a["updated_at"]);
+        const date_b = Date.parse(b["updated_at"]);
+        return date_a > date_b ? -1 : 1;
+    });
+    assets = assets
+        .map(function(asset) {
+            let matches = asset["name"].match(/^ldc2?-([0-9a-fA-F]{5,12})-(.+)/);
+            if (!matches)
+                throw new Error(`Unexpected naming format for the latest LDC asset: ${latest}`);
+            return {
+                name: matches[0],
+                version: matches[1],
+                suffix: matches[2]
+            };
+        })
+        .filter(function(asset) {
+            return asset.suffix == `${suffix}.${ext}`;
+        });
+
+    const latest = assets[0];
+
+    return {
+        name: "ldc2",
+        version: latest.version,
+        url: "https://github.com/ldc-developers/ldc/releases/download/CI/" + latest.name,
+        binpath: (process.platform == "win32") ?
+            `\\ldc2-${latest.version}-${suffix}\\bin` :
+            `/ldc2-${latest.version}-${suffix}/bin`
+    };
+}
+
+async function ldc(version: string, gh_token: string): Promise<CompilerDescription> {
     switch (version) {
         case "latest":
             version = await body_as_text("https://ldc-developers.github.io/LATEST");
@@ -126,37 +182,13 @@ async function ldc(version: string, gh_token: string): Promise<CompilerDescripti
             version = await body_as_text("https://ldc-developers.github.io/LATEST_BETA");
             break;
         case "master":
-            let json = await body_as_text(
-                `https://api.github.com/repos/LDC-Developers/LDC/releases/tags/CI`,
-                gh_token
-            );
-            let assets = JSON.parse(json)["assets"];
-            if (assets == undefined) {
-                console.error("Couldn't load assets json");
-                console.log(json)
-            }
-            if (assets.length == 0)
-                throw new Error("No assets found for LDC CI release");
-            assets.sort(function (a, b) {
-                const date_a = Date.parse(a["updated_at"]);
-                const date_b = Date.parse(b["updated_at"]);
-                return date_a > date_b ? -1 : 1;
-            });
-            const latest = assets[0]["name"];
-            const matches = latest.match(/^ldc2?-([0-9a-fA-F]{5,12})-.+/);
-            if (!matches)
-                throw new Error(`Unexpected naming format for the latest LDC asset: ${latest}`);
-            version = matches[1];
-            ci = true;
-            break;
+            return await ldc_resolve_master(gh_token);
     }
 
-    if (!ci && !version.match(/^(\d+)\.(\d+)\.(\d+)/))
+    if (!version.match(/^(\d+)\.(\d+)\.(\d+)/))
         throw new Error("unrecognized LDC version: " + version);
 
-    const base_url = ci ?
-        `https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-${version}`
-        : `https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc2-${version}`;
+    const base_url = `https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc2-${version}`;
 
     switch (process.platform) {
         case "win32": return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,9 @@ async function run() {
             cached = await tc.cacheDir(dc_path, 'dc', cache_tag);
         }
 
-        core.addPath(cached + descr.binpath);
+        const binpath = cached + descr.binpath;
+        console.log("Adding '" + binpath + "' to path");
+        core.addPath(binpath);
         core.exportVariable("DC", descr.name);
         console.log("Done");
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,8 @@ async function run() {
             throw new Error("Only x64 arch is supported by all platforms");
 
         const input = core.getInput('compiler') || "dmd-latest";
-        const descr = await compiler(input);
+        const gh_token = core.getInput('gh_token') || "";
+        const descr = await compiler(input, gh_token);
 
         console.log(`Enabling ${input}`);
 
@@ -24,7 +25,7 @@ async function run() {
         }
         else {
             console.log(`Downloading ${descr.url}`);
-            const archive = await tc.downloadTool(descr.url);            
+            const archive = await tc.downloadTool(descr.url);
             if (descr.sig)
             {
                 console.log("Verifying the download with GPG");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import * as httpm from 'typed-rest-client/HttpClient';
+import { BearerCredentialHandler } from 'typed-rest-client/Handlers';
 
-export async function body_as_text(url: string): Promise<string> {
-    let client = new httpm.HttpClient("mihails-strasuns/setup-dlang");
+export async function body_as_text(url: string, token: string = ''): Promise<string> {
+    const bearer = token ? [ new BearerCredentialHandler(token) ] : undefined;
+    let client = new httpm.HttpClient("mihails-strasuns/setup-dlang", bearer);
     return (await (await client.get(url)).readBody()).trim();
 }


### PR DESCRIPTION
Fixes #14

The default used access token is generated from a dummy account that
doesn't have any permissions set and/or repo access. It can be overriden
to custom token using configuration if needed.